### PR TITLE
Add NPM package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "uncut_sans",
+  "description": "Yet another slightly quirky sans serif, designed with absolutely no investigation or research into any other typefaces from any specific time period. It tries to capt$
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaspernordkvist/uncut_sans.git"
+  },
+  "keywords": [
+    "font"
+  ],
+  "license": "OFL-1.1",
+  "bugs": {
+    "url": "https://github.com/kaspernordkvist/uncut_sans/issues"
+  },
+  "homepage": "https://github.com/kaspernordkvist/uncut_sans#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uncut_sans",
-  "description": "Yet another slightly quirky sans serif, designed with absolutely no investigation or research into any other typefaces from any specific time period. It tries to capt$
+  "description": "Yet another slightly quirky sans serif, designed with absolutely no investigation or research into any other typefaces from any specific time period. It tries to capture the essence of nothing, really. There’s no deeper meaning behind the design, but hopefully it’s still interesting enough to be taken into consideration for your next project.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kaspernordkvist/uncut_sans.git"


### PR DESCRIPTION
Added a simple `package.json` for easier consuption in our project with NPM.

Note that you don't have to publish the package to https://www.npmjs.com/ — we can consume this now by directly [referering the Github repo URL](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#github-urls).

I also left ["version" field](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#version) out so that it's less work for you, although that would be nice to include and for you to keep up to date. I think this might work without it too, though! Versions would need to be in [semantic versioning format](https://semver.org/), so `1.211.0` instead of `1.211`.


